### PR TITLE
chore(release): version v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CI, audit, and labeler configurations.
+- Additional doc files: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `CHANGELOG.md`, and issue template files.
+
 ## [1.0.0] - 2026-02-16
 
 ### Added
 
 - Initial release.
+
+## [1.0.1] - 2026-02-21
+
+### Changed
+
+- Installation instructions in `README.md` and `lib.rs`.
+
+### Fixed
+
+- `Color` enum’s `value` method to use the `return` keyword.
+
+### Added
+
+- Contributing section to `README.md`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroma-print"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 description = "A lightweight utility for styled terminal printing using ANSI escape codes."
 license = "MIT"


### PR DESCRIPTION
## Release notes

### Changed

- Installation instructions in `README.md` and `lib.rs`.

### Fixed

- `Color` enum’s `value` method to use the `return` keyword.

### Added

- Contributing section to `README.md`.