### PR TITLE
docs(lib): fix typo in installation instructions library cargo doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! $ cargo install chroma-print
 //! ```
 //!
-//! //! ## Install as a library
+//! ## Install as a library
 //! ```console
 //! $ cargo add chroma-print
 //! ```


### PR DESCRIPTION
## Change(s)
- Fix typo in installation instructions for library cargo doc